### PR TITLE
add pattern option & fix mailto crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Options:
   --same-origin          Only visit pages with same origin
   --disable-js           Disable javascript
   --user-agent           Set user agent
+  --pattern              Only follow links that match the supplied regular expression
 ```
 
 Examples
@@ -97,4 +98,9 @@ pappet -rs --same-origin https://example.com
 ##### Only follow relative links
 ```sh
 pappet -rsL https://example.com
+```
+
+##### Only follow relative links
+```sh
+pappet -rp --pattern "/articles/.*" https://example.com
 ```

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pappet -rs --same-origin https://example.com
 pappet -rsL https://example.com
 ```
 
-##### Only follow relative links
+##### Using regular expression 
 ```sh
 pappet -rp --pattern "/articles/.*" https://example.com
 ```

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ const options = {
 const TABS = argv.tabs;
 const log = argv.quit ? function() {} : console.log;
 
-function findAllLinks({ sameOrigin, httpsOnly, relative }) {
+function findAllLinks({ sameOrigin, httpsOnly, relative, pattern }) {
     const allElements = [];
 
     function isAnchor(el) {
@@ -161,7 +161,7 @@ function findAllLinks({ sameOrigin, httpsOnly, relative }) {
     }
 
     function isPattern(el) {
-        return pattern ? new RegExp('/music/.*').test(el.href) : true;
+        return pattern ? new RegExp(pattern).test(el.href) : true;
     }
 
     function findAllLinks() {

--- a/index.js
+++ b/index.js
@@ -113,6 +113,10 @@ yargs.options({
     ['user-agent']: {
         string: true,
         describe: 'Set user agent',
+    },
+    ['pattern']: {
+        string: true,
+        describe: 'Only follow links that match the supplied regular expression',
     }
 });
 
@@ -120,7 +124,7 @@ yargs.usage('Usage: $0 [OPTION]... [URL]...');
 yargs.demandCommand().showHelpOnFail(true).wrap(yargs.terminalWidth());
 
 const argv = yargs.argv;
-const { screenshot, pdf, fullPage, width, height, recursive, userAgent, disableJs } = argv;
+const { screenshot, pdf, fullPage, width, height, recursive, userAgent, disableJs, pattern } = argv;
 
 const options = {
     args: [
@@ -141,7 +145,7 @@ function findAllLinks({ sameOrigin, httpsOnly, relative }) {
     const allElements = [];
 
     function isAnchor(el) {
-        return el.localName === 'a' && el.href !== location.href && el.href;
+        return el.localName === 'a' && el.href !== location.href && !el.href.startsWith('mailto')  && el.href;
     }
 
     function isSameOrigin(el) {
@@ -154,6 +158,10 @@ function findAllLinks({ sameOrigin, httpsOnly, relative }) {
 
     function isRelative(el) {
         return relative ? el.attributes.href.value.indexOf('://') < 1 && el.attributes.href.value.indexOf('//') !== 0 : true;
+    }
+
+    function isPattern(el) {
+        return pattern ? new RegExp('/music/.*').test(el.href) : true;
     }
 
     function findAllLinks() {
@@ -169,6 +177,10 @@ function findAllLinks({ sameOrigin, httpsOnly, relative }) {
 
         if (relative) {
             links = links.filter(isRelative);
+        }
+
+        if (pattern) {
+            links = links.filter(isPattern);
         }
 
         return links.map(el => el.href);


### PR DESCRIPTION
Greetings,

This PR adds _--pattern_ option to support filtering links using a regular expression
also fixes a crash that results from following _mailto:_ links