### PR TITLE
Save page as mhtml & fix saving files starting with .

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Options:
   -t, --tabs             Set number of pages
   -s, --screenshot       Take a screenshot
   -p, --pdf              Take a PDF
+  -m, --mhtml            Save as mhtml
   -r, --recursive        Recursively visit links
   -l, --level            Set recursion depth
   -w, --width            Set page width
@@ -60,6 +61,11 @@ pappet -sf https://example.com
 ##### Take a PDF (-p, --pdf)
 ```sh
 pappet -p https://example.com
+```
+
+##### Save page as mhtml (-m, --mhtml)
+```sh
+pappet -m https://example.com
 ```
 
 ##### Crawl a website recursively and take screenshots (-r, --recursive)


### PR DESCRIPTION
Greetings,

This PR fixes a bug with the path filter saving files like _.pdf_, to reproduce:
`pappet -rp https://dzone.com`
the issue happens when the path contains only _#_, which gets filtered out with slugify, so we end up with an empty string
the reorder fix this issue

Also, adding support to save pages as mhtml